### PR TITLE
Update launch.json to remove incorrect sdkPath property.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,9 @@
             "type": "dart-cli",
             "request": "launch",
             "cwd": "${workspaceRoot}",
-            "sdkPath": "${command.sdkPath}",
             "program": "${workspaceRoot}/bin/demo.dart",
-            "args": []
+            "args": [],
+            "debugSettings": "${command.debugSettings}"
         }
     ]
 }


### PR DESCRIPTION
At the last VSCode and Dart SDK versions. Will close the other PR.